### PR TITLE
RFC5424 compliance

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,8 +13,7 @@ jobs:
     name: Build ${{ matrix.arch }} syslog add-on
     strategy:
       matrix:
-        arch: ["aarch64", "amd64", "armhf", "armv7", "i386"]
-        # arch: ["aarch64"]
+        arch: ["aarch64", "amd64"]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Build syslog add-on
         uses: home-assistant/builder@2025.11.0
         with:
-          image: ${{ contains(fromJson('["armhf", "armv7", "aarch64"]'), matrix.arch) && 'aarch64' || 'amd64' }}
+          image: ${{ matrix.arch }}
           args: |
             ${{ env.TEST_FLAG }} \
             ${{ env.VERSION_FLAG }} \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v5.0.0
+        uses: actions/checkout@v6.0.1
 
       - name: Get information
         id: info
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build syslog add-on
-        uses: home-assistant/builder@2025.09.0
+        uses: home-assistant/builder@2025.11.0
         with:
           image: ${{ contains(fromJson('["armhf", "armv7", "aarch64"]'), matrix.arch) && 'aarch64' || 'amd64' }}
           args: |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Syslog Home Assistant AddOn
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 
  ... to send your HAOS logs to a remote syslog server. UDP and TCP transport is support, as also TLS encrypted transport.
 
@@ -24,6 +24,3 @@ see the add-on [docs](syslog/DOCS.md)
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-yes-green.svg

--- a/syslog/CHANGELOG.md
+++ b/syslog/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.2
+
+- Make messages RF5424 compliant
+
 ## 0.4.1
 
 - Fix tagging of containers

--- a/syslog/CHANGELOG.md
+++ b/syslog/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.4.2
 
-- Make messages RF5424 compliant
+- Add RF5424 compliant format option
+- Remove obsolete architectures armv7, armhf, i386 (no longer supported as of Home Assistant 2025.11.0)
 
 ## 0.4.1
 

--- a/syslog/CHANGELOG.md
+++ b/syslog/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.2
 
-- Add RF5424 compliant format option
+- Add RFC5424 compliant format option
 - Remove obsolete architectures armv7, armhf, i386 (no longer supported as of Home Assistant 2025.11.0)
 
 ## 0.4.1

--- a/syslog/build.yaml
+++ b/syslog/build.yaml
@@ -1,9 +1,9 @@
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base-debian:bookworm"
-  amd64: "ghcr.io/home-assistant/amd64-base-debian:bookworm"
-  armhf: "ghcr.io/home-assistant/armhf-base-debian:bookworm"
-  armv7: "ghcr.io/home-assistant/armv7-base-debian:bookworm"
-  i386: "ghcr.io/home-assistant/i386-base-debian:bookworm"
+  aarch64: "ghcr.io/home-assistant/aarch64-base-debian:trixie"
+  amd64: "ghcr.io/home-assistant/amd64-base-debian:trixie"
+  armhf: "ghcr.io/home-assistant/armhf-base-debian:trixie"
+  armv7: "ghcr.io/home-assistant/armv7-base-debian:trixie"
+  i386: "ghcr.io/home-assistant/i386-base-debian:trixie"
 labels:
   org.opencontainers.image.title: "Syslog"
   org.opencontainers.image.description: "Send your HAOS logs to a remote syslog server"

--- a/syslog/build.yaml
+++ b/syslog/build.yaml
@@ -1,9 +1,6 @@
 build_from:
   aarch64: "ghcr.io/home-assistant/aarch64-base-debian:trixie"
   amd64: "ghcr.io/home-assistant/amd64-base-debian:trixie"
-  armhf: "ghcr.io/home-assistant/armhf-base-debian:trixie"
-  armv7: "ghcr.io/home-assistant/armv7-base-debian:trixie"
-  i386: "ghcr.io/home-assistant/i386-base-debian:trixie"
 labels:
   org.opencontainers.image.title: "Syslog"
   org.opencontainers.image.description: "Send your HAOS logs to a remote syslog server"

--- a/syslog/config.yaml
+++ b/syslog/config.yaml
@@ -1,5 +1,5 @@
 name: "Syslog"
-version: "0.4.1"
+version: "0.4.2"
 slug: "syslog"
 description: "Send your HAOS logs to a remote syslog server"
 url: "https://github.com/mib1185/ha-addon-syslog"

--- a/syslog/config.yaml
+++ b/syslog/config.yaml
@@ -6,9 +6,6 @@ url: "https://github.com/mib1185/ha-addon-syslog"
 arch:
   - aarch64
   - amd64
-  - armhf
-  - armv7
-  - i386
 image: mib85/{arch}-ha-addon-syslog
 init: false
 startup: services

--- a/syslog/config.yaml
+++ b/syslog/config.yaml
@@ -16,9 +16,11 @@ options:
   syslog_protocol: udp
   syslog_ssl: false
   syslog_ssl_verify: true
+  syslog_format: RFC3164
 schema:
   syslog_host: str
   syslog_port: int
   syslog_protocol: list(udp|tcp)
   syslog_ssl: bool
   syslog_ssl_verify: bool
+  syslog_format: list(RFC3164|RFC5424)

--- a/syslog/journal2syslog.py
+++ b/syslog/journal2syslog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import logging
 import logging.handlers
 import re
@@ -119,6 +120,13 @@ class TlsSysLogHandler(logging.handlers.SysLogHandler):
             self.socktype = socktype
 
 
+class RFC5424Formatter(logging.Formatter):
+    def formatTime(self, record, datefmt=None):
+        """Return the creation time of the specified LogRecord as formatted text."""
+        dt = datetime.datetime.fromtimestamp(record.created, datetime.timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
 def parse_log_level(message: str, container_name: str) -> int:
     """
     Try to determine logging level from message
@@ -159,10 +167,9 @@ if SYSLOG_SSL and not SYSLOG_SSL_VERIFY:
 syslog_handler = TlsSysLogHandler(
     address=(SYSLOG_HOST, SYSLOG_PORT), socktype=socktype, ssl=use_ssl
 )
-formatter = logging.Formatter(
-    f"%(asctime)s %(ip)s %(prog)s: %(message)s",
+formatter = RFC5424Formatter(
+    fmt="1 %(asctime)s %(ip)s %(prog)s %(procid)s - - %(message)s",
     defaults={"ip": HAOS_HOSTNAME},
-    datefmt="%b %d %H:%M:%S",
 )
 syslog_handler.setFormatter(formatter)
 logger.addHandler(syslog_handler)
@@ -173,13 +180,19 @@ last_container_log_level: dict[str, int] = {}
 while True:
     change = jr.wait(timeout=None)
     for entry in jr:
-        extra = {"prog": entry.get("SYSLOG_IDENTIFIER")}
+        # RFC 5424 parameters
+        prog = entry.get("SYSLOG_IDENTIFIER") or "-"
+        procid = entry.get("_PID") or "-"
+        extra = {"prog": prog, "procid": procid}
 
         # remove shell colors from container messages
         if (container_name := entry.get("CONTAINER_NAME")) is not None:
             msg = re.sub(r"\x1b\[\d+m", "", entry.get("MESSAGE"))
         else:
             msg = entry.get("MESSAGE")
+
+        if isinstance(msg, str):
+            msg = msg.replace("\n", "#012").replace("\r", "")
 
         # determine syslog level
         if not container_name:

--- a/syslog/journal2syslog.py
+++ b/syslog/journal2syslog.py
@@ -15,6 +15,7 @@ SYSLOG_PORT = int(environ["SYSLOG_PORT"])
 SYSLOG_PROTO = str(environ["SYSLOG_PROTO"])
 SYSLOG_SSL = True if environ["SYSLOG_SSL"] == "true" else False
 SYSLOG_SSL_VERIFY = True if environ["SYSLOG_SSL_VERIFY"] == "true" else False
+SYSLOG_FORMAT = environ.get("SYSLOG_FORMAT", "RFC3164")
 HAOS_HOSTNAME = str(environ["HAOS_HOSTNAME"])
 
 LOGGING_NAME_TO_LEVEL_MAPPING = logging.getLevelNamesMapping()
@@ -124,7 +125,7 @@ class RFC5424Formatter(logging.Formatter):
     def formatTime(self, record, datefmt=None):
         """Return the creation time of the specified LogRecord as formatted text."""
         dt = datetime.datetime.fromtimestamp(record.created, datetime.timezone.utc)
-        return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        return dt.isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
 def parse_log_level(message: str, container_name: str) -> int:
@@ -167,10 +168,19 @@ if SYSLOG_SSL and not SYSLOG_SSL_VERIFY:
 syslog_handler = TlsSysLogHandler(
     address=(SYSLOG_HOST, SYSLOG_PORT), socktype=socktype, ssl=use_ssl
 )
-formatter = RFC5424Formatter(
-    fmt="1 %(asctime)s %(ip)s %(prog)s %(procid)s - - %(message)s",
-    defaults={"ip": HAOS_HOSTNAME},
-)
+
+if SYSLOG_FORMAT == "RFC5424":
+    formatter = RFC5424Formatter(
+        fmt="1 %(asctime)s %(ip)s %(prog)s %(procid)s - - %(message)s",
+        defaults={"ip": HAOS_HOSTNAME},
+    )
+else:
+    formatter = logging.Formatter(
+        fmt="%(asctime)s %(ip)s %(prog)s: %(message)s",
+        defaults={"ip": HAOS_HOSTNAME},
+        datefmt="%b %d %H:%M:%S",
+    )
+
 syslog_handler.setFormatter(formatter)
 logger.addHandler(syslog_handler)
 
@@ -180,18 +190,21 @@ last_container_log_level: dict[str, int] = {}
 while True:
     change = jr.wait(timeout=None)
     for entry in jr:
-        # RFC 5424 parameters
-        prog = entry.get("SYSLOG_IDENTIFIER") or "-"
-        procid = entry.get("_PID") or "-"
-        extra = {"prog": prog, "procid": procid}
+        if SYSLOG_FORMAT == "RFC5424":
+            # RFC 5424 parameters
+            prog = entry.get("SYSLOG_IDENTIFIER") or "-"
+            procid = entry.get("_PID") or "-"
+            extra = {"prog": prog, "procid": procid}
+        else:
+            extra = {"prog": entry.get("SYSLOG_IDENTIFIER")}
 
         # remove shell colors from container messages
         if (container_name := entry.get("CONTAINER_NAME")) is not None:
-            msg = re.sub(r"\x1b\[\d+m", "", entry.get("MESSAGE"))
+            msg = re.sub(r"\x1b[[\]\d+m", "", entry.get("MESSAGE"))
         else:
             msg = entry.get("MESSAGE")
 
-        if isinstance(msg, str):
+        if SYSLOG_FORMAT == "RFC5424" and isinstance(msg, str):
             msg = msg.replace("\n", "#012").replace("\r", "")
 
         # determine syslog level

--- a/syslog/journal2syslog.py
+++ b/syslog/journal2syslog.py
@@ -200,7 +200,7 @@ while True:
 
         # remove shell colors from container messages
         if (container_name := entry.get("CONTAINER_NAME")) is not None:
-            msg = re.sub(r"\x1b[[\]\d+m", "", entry.get("MESSAGE"))
+            msg = re.sub(r"\x1b\[[0-9;]*m", "", entry.get("MESSAGE"))
         else:
             msg = entry.get("MESSAGE")
 

--- a/syslog/run.sh
+++ b/syslog/run.sh
@@ -12,6 +12,8 @@ SYSLOG_SSL=$(bashio::config 'syslog_ssl')
 export SYSLOG_SSL
 SYSLOG_SSL_VERIFY=$(bashio::config 'syslog_ssl_verify')
 export SYSLOG_SSL_VERIFY
+SYSLOG_FORMAT=$(bashio::config 'syslog_format')
+export SYSLOG_FORMAT
 HAOS_HOSTNAME=$(bashio::info.hostname)
 export HAOS_HOSTNAME
 

--- a/syslog/translations/de.yaml
+++ b/syslog/translations/de.yaml
@@ -14,3 +14,6 @@ configuration:
   syslog_ssl_verify:
     name: SSL-Zertifikat überprüfen
     description: Prüfung des SSL-Zertifikate aktivieren oder dekativieren.
+  syslog_format:
+    name: Syslog Format
+    description: Das Format der Syslog-Nachricht.

--- a/syslog/translations/en.yaml
+++ b/syslog/translations/en.yaml
@@ -14,3 +14,6 @@ configuration:
   syslog_ssl_verify:
     name: SSL verify
     description: Whether or not to verify ssl certificate.
+  syslog_format:
+    name: Syslog format
+    description: The format of the syslog message.


### PR DESCRIPTION
I was trying to send HA logs to Grafana Alloy which has standard-compliant parsers for RFC3164 and RFC5424. Unfortunately, as noted in https://github.com/mib1185/ha-addon-syslog/pull/27, version 0.4.1 of this add-on doesn't conform to either standard.

This PR is similar to #27 but adds a dropdown option for the syslog format with the previous format as the default and a new RFC5424-compliant option.

The PR also bumps a few dependencies and drops the architectures which were recently removed from the HA builder.