### PR TITLE
fix: resolve container boot ID mismatch in journal reader

### DIFF
--- a/syslog/journal2syslog.py
+++ b/syslog/journal2syslog.py
@@ -135,11 +135,16 @@ def parse_log_level(message: str, container_name: str) -> int:
 
 
 # start journal reader and seek to end of journal
+#
+# NOTE: Intentionally NOT calling jr.this_boot() here.
+# In containers (like HA add-ons), the boot ID from
+# /proc/sys/kernel/random/boot_id is the container's boot ID, which
+# doesn't match any boot ID in the host's journal (mounted from
+# /var/log/journal). this_boot() would silently filter out ALL entries,
+# causing the add-on to appear working but never forward any logs.
 jr = journal.Reader(path="/var/log/journal")
-jr.this_boot()
 jr.seek_tail()
 jr.get_previous()
-jr.get_next()
 
 # start logger
 logger = logging.getLogger("")


### PR DESCRIPTION
In certain containers setups like systemd-nspawn (including rootless podman/crun under nspawn) and LXC, the container's boot ID can differ from the host's boot ID. `this_boot()` filters for the container's boot ID which doesn't exist in the host journal, resulting in zero entries being read. The add-on will appear to work but silently forwards nothing.

Fix by removing this_boot() and using seek_tail() directly. Also remove the redundant get_next() call after get_previous().

Tested and working, but haven't tested the failure scenario as I'm using HAOS. I'm [maintaining a fork](https://github.com/UberKitten/ha-addon-syslog) with this fix for anyone to use.